### PR TITLE
Corrected URL for Cornac

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                     </tr>
 
                     <tr>
-                        <td><a href="http://php-cartography.alterway.fr">Cornac</a></td>
+                        <td><a href="https://github.com/alterway/cornac">Cornac</a></td>
                         <td>Outil d'analyse de code PHP</td>
                         <td>PHP-3.01</td>
                         <td>Créateur</td>


### PR DESCRIPTION
Ideally should point to http://www.cornac.info/ but URL is brokem ATM.
